### PR TITLE
Fix Issue #1 on ZSH

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ PS1="$(pista -m)" # minimal variant
 ```shell
 autoinit -Uz add-zsh-hook
 _pista_prompt() {
-	PROMPT=$("pista")   # `pista -m` for the miminal variant
+	PROMPT=$("pista -z")   # `pista -zm` for the miminal variant
 }
 add-zsh-hook precmd _pista_prompt
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn pista() -> String {
     let (branch, status) = vcs::vcs_status().unwrap_or(("".into(), "".into()));
     let venv = venv::get_name();
     let prompt_char = prompt_char::get_char();
-    format!("{cwd} {branch} {status}\n{venv}{pchar} ",
+    format!("%{{{cwd} {branch} {status}%}} %{{\n{venv}{pchar}%}} ",
             cwd=cwd,
             branch=branch,
             status=status,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,29 +15,44 @@ fn main() {
              .long("minimal")
              .help("use minimal variant")
         )
+        .arg(Arg::with_name("zsh")
+             .short("z")
+             .long("zsh")
+             .help("Use ZSH formatting")
+        )
         .get_matches();
     if matches.is_present("minimal") {
-        println!("{}", pista_minimal());
+        println!("{}", pista_minimal(matches.is_present("zsh")));
     } else {
-        println!("{}", pista());
+        println!("{}", pista(matches.is_present("zsh")));
     }
 }
 
-fn pista() -> String {
+fn pista(zsh: bool) -> String {
     let cwd = cwd::cwd();
     let (branch, status) = vcs::vcs_status().unwrap_or(("".into(), "".into()));
     let venv = venv::get_name();
     let prompt_char = prompt_char::get_char();
-    format!("%{{{cwd} {branch} {status}%}} %{{\n{venv}{pchar}%}} ",
+    if zsh {
+        format!("%{{{cwd} {branch} {status}%}} %{{\n{venv}{pchar}%}} ",
             cwd=cwd,
             branch=branch,
             status=status,
             venv=venv,
             pchar=prompt_char
             )
+    } else {
+        format!("{cwd} {branch} {status}\n{venv}{pchar} ",
+            cwd=cwd,
+            branch=branch,
+            status=status,
+            venv=venv,
+            pchar=prompt_char
+            )
+    }
 }
 
-fn pista_minimal() -> String {
+fn pista_minimal(zsh: bool) -> String {
     let cwd = cwd::cwd();
     let vcs_tuple = vcs::vcs_status();
     let mut vcs_component = String::new();
@@ -48,10 +63,39 @@ fn pista_minimal() -> String {
     }
     let venv = venv::get_name();
     let prompt_char = prompt_char::get_char();
-    format!("{cwd}{vcs}{venv}{pchar} ",
+    if zsh {
+        let fmt = format!("{cwd}{vcs}{venv}{pchar} ",
+            cwd=cwd,
+            vcs=vcs_component,
+            venv=venv,
+            pchar=prompt_char
+        );
+        let mut ret = String::new();
+        let mut color = false;
+        for ch in fmt.chars() {
+            if color {
+                if ch == 'm' { // colors always end with m
+                    ret.push_str("m%}");
+                    color = false;
+                } else {
+                    ret.push(ch)
+                }
+            } else {
+                if ch == 0x1b_u8.into() { // ESC char, always starts colors
+                    ret.push_str(&format!("%{{{esc}", esc=ch));
+                    color = true;
+                } else {
+                    ret.push(ch);
+                }
+            }
+        }
+        ret
+    } else {
+        format!("{cwd}{vcs}{venv}{pchar} ",
             cwd=cwd,
             vcs=vcs_component,
             venv=venv,
             pchar=prompt_char
             )
+    }
 }


### PR DESCRIPTION
Some of the code is a bit of a hack, but in my testing it works perfectly. It works by explicitly telling ZSH that the color characters are zero-width (denoted by `%{` and `%}`). Unfortunately, BASH doesn't seem to support this notation, so I left the theme unchanged if the `-z` flag isn't supplied.