### PR TITLE
add HIDE_HOME_CWD config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,9 @@ export CWD_COLOR="white"
 # if EXPAND_TILDE is set to 0, `/home/nerdypepper` is shortened to `~`
 export EXPAND_TILDE=0
 
+# if HIDE_HOME_CWD is set to 1, path is hidden when in $HOME
+export HIDE_HOME_CWD=1
+
 # there are three possible states for a git repo
 # - unstaged (working tree has been modified) 
 # - staged (staging area has been modified)

--- a/src/cwd.rs
+++ b/src/cwd.rs
@@ -1,11 +1,22 @@
+use colored::*;
 use std::env;
 use tico::tico;
-use colored::*;
 
 pub fn cwd() -> Option<colored::ColoredString> {
     let path_env = env::current_dir().ok()?;
     let mut path = format!("{}", path_env.display());
     let home = env::var("HOME").unwrap();
+
+    let hide_home = env::var("HIDE_HOME_CWD").unwrap_or("0".into());
+    match hide_home.as_ref() {
+        "0" => {}
+        _ => {
+            if &path == &home {
+                return Some(colored::ColoredString::from(""));
+            }
+        }
+    }
+
     let tilde_expand = env::var("EXPAND_TILDE").unwrap_or("0".into());
 
     match tilde_expand.as_ref() {
@@ -23,7 +34,6 @@ pub fn cwd() -> Option<colored::ColoredString> {
     let cwd_color = env::var("CWD_COLOR").unwrap_or("white".into());
     match cwd_shorten.as_ref() {
         "0" => return Some(path.color(cwd_color)),
-        _ => return Some(tico(&path).color(cwd_color))
+        _ => return Some(tico(&path).color(cwd_color)),
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn pista(zsh: bool) -> String {
     };
     let (branch, status) = match env::var("DISABLE_VCS").unwrap_or("0".into()).as_ref() {
         "0" => vcs::vcs_status().unwrap_or(("".into(), "".into())),
-        _ => ("".into(), "".into())
+        _ => ("".into(), "".into()),
     };
     let venv = venv::get_name();
     let prompt_char = prompt_char::get_char();
@@ -75,7 +75,7 @@ fn pista_minimal(zsh: bool) -> String {
     let mut vcs_component = String::new();
     if let Some((branch, status)) = vcs_tuple {
         vcs_component = format!(" [{} {}] ", branch, status);
-    } else {
+    } else if cwd.len() > 0 {
         vcs_component.push(' ');
     }
     let venv = venv::get_name();


### PR DESCRIPTION
Hides path if in $HOME. It only shows the prompt char, as usually $HOME
has no git repo. Looks pretty cool when opening a new terminal.

Note: my rust formatter has added 3 irrelevant formatting changes. I think they are consistent, but if this annoys anybody, then I can remove them.